### PR TITLE
Purge a list of urls, update tests to use webmock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.rbc
 pkg
 spec/config.yml
+.bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,21 @@
 PATH
   remote: .
   specs:
-    highwinds-api (0.0.8)
+    highwinds-api (0.1.1)
       httparty (= 0.10.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.4.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.1.3)
+    hashdiff (0.3.0)
     httparty (0.10.2)
       multi_json (~> 1.0)
       multi_xml (>= 0.5.2)
-    multi_json (1.11.0)
+    multi_json (1.12.1)
     multi_xml (0.5.5)
     rake (0.9.6)
     rspec (2.11.0)
@@ -22,6 +26,11 @@ GEM
     rspec-expectations (2.11.3)
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.3)
+    safe_yaml (1.0.4)
+    webmock (2.0.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -30,3 +39,7 @@ DEPENDENCIES
   highwinds-api!
   rake (~> 0.9)
   rspec (~> 2.11)
+  webmock
+
+BUNDLED WITH
+   1.12.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    highwinds-api (0.1.1)
+    highwinds-api (1.0.0)
       httparty (= 0.10.2)
 
 GEM

--- a/highwinds-api.gemspec
+++ b/highwinds-api.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.add_dependency "httparty", "0.10.2"
   gem.add_development_dependency "rspec", "~> 2.11"
+  gem.add_development_dependency "webmock"
 end

--- a/lib/highwinds-api/content.rb
+++ b/lib/highwinds-api/content.rb
@@ -29,6 +29,8 @@ module HighwindsAPI
       self.post("/api/v1/accounts/#{get_account_hash}/purge", options)
     end
 
+    # N.B. this is an undocumented method, so use at your own risk
+    # it may not continue to work based on highwinds / striketracker changes
     def self.purge_progress(purge_id)
       options = { headers: { 'Authorization' => HighwindsAPI.get_token } }
       self.get("/api/v1/accounts/#{get_account_hash}/purge/#{purge_id}", options)

--- a/lib/highwinds-api/content.rb
+++ b/lib/highwinds-api/content.rb
@@ -29,18 +29,23 @@ module HighwindsAPI
       self.post("/api/v1/accounts/#{get_account_hash}/purge", options)
     end
 
+    def self.purge_progress(purge_id)
+      options = { headers: { 'Authorization' => HighwindsAPI.get_token } }
+      self.get("/api/v1/accounts/#{get_account_hash}/purge/#{purge_id}", options)
+    end
+
     private
 
     def self.get_token
       options = {
         body: {
           grant_type: 'password',
-          username: HighwindsAPI.credentials[:username],
-          password: HighwindsAPI.credentials[:password]
+          username: "#{HighwindsAPI.credentials[:username]}",
+          password: "#{HighwindsAPI.credentials[:password]}"
         }
       }
 
-      response = self.post("/auth/token", body: options)
+      response = self.post("/auth/token", options)
       "Bearer #{response['access_token']}"
     end
 

--- a/lib/highwinds-api/version.rb
+++ b/lib/highwinds-api/version.rb
@@ -1,5 +1,5 @@
 module Highwinds
   module Api
-    VERSION = "0.1.1"
+    VERSION = "1.0.0"
   end
 end

--- a/spec/content_spec.rb
+++ b/spec/content_spec.rb
@@ -1,7 +1,7 @@
-require 'highwinds-api'
+require 'spec_helper'
 
 describe HighwindsAPI::Content do
-  let(:config) { YAML.load_file('spec/config.yml') }
+  let(:config) { load_config }
   let(:client) { HighwindsAPI }
   let(:content) { client::Content }
 
@@ -12,6 +12,18 @@ describe HighwindsAPI::Content do
     end
 
     it "does not purge content" do
+      stub_request(:post, "https://striketracker3.highwinds.com/auth/token").
+        with(body: "body[grant_type]=password&body[username]=bad-username&body[password]=bad-password").
+        to_return(status: 401, body: '{"error": "This endpoint requires authentication","code": 203}', :headers => { content_type: 'application/json' })
+
+      stub_request(:get, "https://striketracker3.highwinds.com/api/v1/users/me").
+        with(:headers => {'Authorization'=>'Bearer'}).
+        to_return(status: 401, body: '{"error": "This endpoint requires authentication","code": 203}', :headers => { content_type: 'application/json' })
+
+      stub_request(:post, "https://striketracker3.highwinds.com/api/v1/accounts//purge").
+        with(body: "{\"list\":[{\"url\":\"http://staging.crossrider.com/kerker/\",\"recursive\":true}]}").
+        to_return(status: 401, body: '{"error": "This endpoint requires authentication","code": 203}', :headers => { content_type: 'application/json' })
+
       response = content.purge_url("http://staging.crossrider.com/kerker/", true).response
       expect(response.code).to eq("401")
     end
@@ -21,30 +33,63 @@ describe HighwindsAPI::Content do
     before do
       client.clear_token
       client.set_credentials(config["username"], config["password"])
+
+      stub_request(:post, "https://striketracker3.highwinds.com/auth/token").
+        with(:body => "body[grant_type]=password&body[username]=u&body[password]=p").
+        to_return(:status => 200, :body => '{"access_token": "atoken"}', :headers => { content_type: 'application/json' })
+
+      stub_request(:get, "https://striketracker3.highwinds.com/api/v1/users/me").
+        with(:headers => {'Authorization'=>'Bearer atoken'}).
+        to_return(:status => 200, :body => '{"accountHash": "12345"}', :headers => { content_type: 'application/json' })
     end
 
     it "should purge content by url" do
+      stub_request(:post, "https://striketracker3.highwinds.com/api/v1/accounts/12345/purge").
+        with(:body => "{\"list\":[{\"url\":\"http://staging.crossrider.com/kerker/\",\"recursive\":true}]}",
+             :headers => {'Authorization'=>'Bearer atoken', 'Content-Type'=>'application/json'}).
+        to_return(:status => 200, :body => '{"id":"id"}', :headers => { content_type: 'application/json' })
+
       response = content.purge_url("http://staging.crossrider.com/kerker/", true)
       response.include?("id").should eq(true), "response was: #{response}"
     end
 
     it "should purge folder by path" do
+      stub_request(:post, "https://striketracker3.highwinds.com/api/v1/accounts/12345/purge").
+        with(:body => "{\"list\":[{\"url\":\"http://cds.y2s9x4y9.hwcdn.net/kerker/\",\"recursive\":true}]}",
+             :headers => {'Authorization'=>'Bearer atoken', 'Content-Type'=>'application/json'}).
+        to_return(:status => 200, :body => '{"id":"id"}', :headers => { content_type: 'application/json' })
+
       response = content.purge_path("y2s9x4y9", "/kerker/").response
       response.code.should eq("200"), "response was: #{response} and response code was #{response.code} and response text #{response.body}"
     end
 
     it "should purge file by path" do
+      stub_request(:post, "https://striketracker3.highwinds.com/api/v1/accounts/12345/purge").
+        with(:body => "{\"list\":[{\"url\":\"http://cds.y2s9x4y9.hwcdn.net/kerker/akamai\",\"recursive\":true}]}",
+             :headers => {'Authorization'=>'Bearer atoken', 'Content-Type'=>'application/json'}).
+        to_return(:status => 200, :body => '{"id":"id"}', :headers => { content_type: 'application/json' })
+
       response = content.purge_path("y2s9x4y9", "kerker/akamai").response
       response.code.should eq("200"), "response was: #{response}"
     end
 
     it "should purge folders by array of pathes" do
+      stub_request(:post, "https://striketracker3.highwinds.com/api/v1/accounts/12345/purge").
+        with(:body => "{\"list\":[{\"url\":\"http://cds.y2s9x4y9.hwcdn.net/kerker/akamai.txt\",\"recursive\":true},{\"url\":\"http://cds.y2s9x4y9.hwcdn.net/kerker/akamai.htm\",\"recursive\":true},{\"url\":\"http://cds.y2s9x4y9.hwcdn.net/kerker/akamai.gif\",\"recursive\":true}]}",
+             :headers => {'Authorization'=>'Bearer atoken', 'Content-Type'=>'application/json'}).
+        to_return(:status => 200, :body => '{"id":"id"}', :headers => { content_type: 'application/json' })
+
       arr = ["kerker/akamai.txt", "kerker/akamai.htm", "kerker/akamai.gif"]
       response = content.purge_path("y2s9x4y9", arr).response
       response.code.should eq("200"), "response was: #{response}"
     end
 
     it "should ignore pathes ending with * (purge by path is allways recuresive)" do
+      stub_request(:post, "https://striketracker3.highwinds.com/api/v1/accounts/12345/purge").
+        with(:body => "{\"list\":[{\"url\":\"http://cds.y2s9x4y9.hwcdn.net/kerker/*\",\"recursive\":true}]}",
+             :headers => {'Authorization'=>'Bearer atoken', 'Content-Type'=>'application/json'}).
+        to_return(:status => 200, :body => '{"id":"id"}', :headers => { content_type: 'application/json' })
+
       response = content.purge_path("y2s9x4y9", "kerker/*").response
       response.code.should eq("200"), "response was: #{response}"
     end
@@ -57,35 +102,50 @@ describe HighwindsAPI::Content do
     let(:recursive) { false }
     let(:account_hash) {"d3b5s7n9"}
 
-     describe ".purge_url" do
-       it "calls post with given params" do
-        HighwindsAPI.clear_token
-        HighwindsAPI.set_credentials(config["username"], config["password"])      
+    before do
+      client.clear_token
+      client.set_credentials(config["username"], config["password"])
+
+      stub_request(:post, "https://striketracker3.highwinds.com/auth/token").
+        with(:body => "body[grant_type]=password&body[username]=u&body[password]=p").
+        to_return(:status => 200, :body => '{"access_token":"atoken"}', :headers => { content_type: 'application/json' })
+
+      stub_request(:get, "https://striketracker3.highwinds.com/api/v1/users/me").
+        with(:headers => {'Authorization'=>'Bearer atoken'}).
+        to_return(:status => 200, :body => '{"accountHash":"d3b5s7n9"}', :headers => { content_type: 'application/json' })
+
+      HighwindsAPI.clear_token
+      HighwindsAPI.set_credentials(config["username"], config["password"])
+    end
+
+    describe ".purge_url" do
+
+      it "calls post with given params" do
         options = {
-          :headers    =>  { 'Authorization'  => HighwindsAPI.get_token,
-                'Content-Type' => 'application/json'},
-          :body =>  {"list" => [{url: url, recursive: recursive }]}.to_json }
-         
-         content.should_receive(:post).\
-           with("/api/v1/accounts/#{account_hash}/purge", options).\
-           and_return("403")
-         content.purge_url(url, recursive)
-       end
-     end
+          :headers => { 'Authorization' => HighwindsAPI.get_token,
+                        'Content-Type' => 'application/json' },
+          :body => {"list" => [{ url: url, recursive: recursive }] }.to_json
+        }
+
+        content.should_receive(:post).
+          with("/api/v1/accounts/#{account_hash}/purge", options).
+          and_return("403")
+        content.purge_url(url, recursive)
+      end
+    end
 
 
-     describe ".purge_path" do
-       it "calls post with given params" do
-        HighwindsAPI.clear_token
-        HighwindsAPI.set_credentials(config["username"], config["password"])      
+    describe ".purge_path" do
+      it "calls post with given params" do
         options = {
-          :headers    =>  { 'Authorization'  => HighwindsAPI.get_token,
-                'Content-Type' => 'application/json'},
-          :body =>  {"list" => [{url: "http://cds.xxxxxxxx.hwcdn.net/baz/*", recursive: true }]}.to_json }
-         content.should_receive(:post).\
-           with("/api/v1/accounts/#{account_hash}/purge", options).\
-           and_return("403")
-         content.purge_path(host_hash, path)
+          :headers => { 'Authorization' => HighwindsAPI.get_token,
+                        'Content-Type' => 'application/json' },
+          :body => { "list" => [{ url: "http://cds.xxxxxxxx.hwcdn.net/baz/*", recursive: true }] }.to_json
+        }
+        content.should_receive(:post).\
+          with("/api/v1/accounts/#{account_hash}/purge", options).
+          and_return("403")
+        content.purge_path(host_hash, path)
        end
      end
   end

--- a/spec/content_spec.rb
+++ b/spec/content_spec.rb
@@ -161,8 +161,21 @@ describe HighwindsAPI::Content do
           with("/api/v1/accounts/#{account_hash}/purge", options).
           and_return("403")
         content.purge_path(host_hash, path)
-       end
-     end
-  end
+      end
+    end
 
+    describe ".purge" do
+      it "calls post with given params" do
+        options = {
+          :headers => { 'Authorization' => HighwindsAPI.get_token,
+                        'Content-Type' => 'application/json' },
+          :body => { "list" => [{ url: "http://cds.xxxxxxxx.hwcdn.net/baz/*", recursive: true }] }.to_json
+        }
+        content.should_receive(:post).\
+          with("/api/v1/accounts/#{account_hash}/purge", options).
+          and_return("403")
+        content.purge([{ url: "http://cds.xxxxxxxx.hwcdn.net/baz/*", recursive: true }])
+      end
+    end
+  end
 end

--- a/spec/content_spec.rb
+++ b/spec/content_spec.rb
@@ -73,7 +73,7 @@ describe HighwindsAPI::Content do
       response.code.should eq("200"), "response was: #{response}"
     end
 
-    it "should purge folders by array of pathes" do
+    it "should purge folders by array of paths" do
       stub_request(:post, "https://striketracker3.highwinds.com/api/v1/accounts/12345/purge").
         with(:body => "{\"list\":[{\"url\":\"http://cds.y2s9x4y9.hwcdn.net/kerker/akamai.txt\",\"recursive\":true},{\"url\":\"http://cds.y2s9x4y9.hwcdn.net/kerker/akamai.htm\",\"recursive\":true},{\"url\":\"http://cds.y2s9x4y9.hwcdn.net/kerker/akamai.gif\",\"recursive\":true}]}",
              :headers => {'Authorization'=>'Bearer atoken', 'Content-Type'=>'application/json'}).
@@ -84,7 +84,22 @@ describe HighwindsAPI::Content do
       response.code.should eq("200"), "response was: #{response}"
     end
 
-    it "should ignore pathes ending with * (purge by path is allways recuresive)" do
+    it "should purge list of urls" do
+      stub_request(:post, "https://striketracker3.highwinds.com/api/v1/accounts/12345/purge").
+        with(:body => "{\"list\":[{\"url\":\"http://cds.y2s9x4y9.hwcdn.net/kerker/akamai.txt\",\"recursive\":true},{\"url\":\"http://cds.y2s9x4y9.hwcdn.net/kerker/akamai.htm\",\"recursive\":true},{\"url\":\"http://cds.y2s9x4y9.hwcdn.net/kerker/akamai.gif\",\"recursive\":true}]}",
+             :headers => {'Authorization'=>'Bearer atoken', 'Content-Type'=>'application/json'}).
+        to_return(:status => 200, :body => '{"id":"id"}', :headers => { content_type: 'application/json' })
+
+      arr = [
+        { url: "http://cds.y2s9x4y9.hwcdn.net/kerker/akamai.txt", recursive: true},
+        { url: "http://cds.y2s9x4y9.hwcdn.net/kerker/akamai.htm", recursive: true},
+        { url: "http://cds.y2s9x4y9.hwcdn.net/kerker/akamai.gif", recursive: true}
+      ]
+      response = content.purge(arr).response
+      response.code.should eq("200"), "response was: #{response}"
+    end
+
+    it "should ignore paths ending with * (purge by path is allways recuresive)" do
       stub_request(:post, "https://striketracker3.highwinds.com/api/v1/accounts/12345/purge").
         with(:body => "{\"list\":[{\"url\":\"http://cds.y2s9x4y9.hwcdn.net/kerker/*\",\"recursive\":true}]}",
              :headers => {'Authorization'=>'Bearer atoken', 'Content-Type'=>'application/json'}).

--- a/spec/highwinds-api_spec.rb
+++ b/spec/highwinds-api_spec.rb
@@ -1,7 +1,13 @@
-require 'highwinds-api'
+require 'spec_helper'
 
 describe HighwindsAPI do
-  let(:config) { YAML.load_file('spec/config.yml') }
+  let(:config) { load_config }
+
+  before do
+    subject.clear_token
+    stub_request(:post, "https://striketracker3.highwinds.com/auth/token").
+      to_return(:status => 200, :body => '{"access_token": "atokenatokenatoken"}', :headers => { content_type: 'application/json' })
+  end
 
   it "set credentials" do
     username = "user"
@@ -12,7 +18,7 @@ describe HighwindsAPI do
 
   it "get token" do
     subject.set_credentials(config["username"], config["password"])
-    expect(subject.get_token.length).to be  >= 20
+    expect(subject.get_token.length).to be >= 20
   end
 
   it "get token snd time to be the same as first one" do
@@ -21,7 +27,6 @@ describe HighwindsAPI do
     new_token = subject.get_token
     expect(new_token).to be(old_token)
   end
-
 
   it "autoloads ::Content" do
     # subject.autoload?(:Content).should eq("highwinds-api/content")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,16 @@
+require 'rubygems'
+require 'bundler/setup'
+
+require 'rspec'
+require 'webmock/rspec'
+require 'highwinds-api'
+
+def load_config
+  if ENV['HIGHWINDS_TEST_REMOTE']
+    YAML.load_file('spec/config.yml')
+  else
+    { "username" => "u", "password" => "p" }
+  end
+end
+
+WebMock.disable_net_connect! if ENV['HIGHWINDS_TEST_REMOTE']


### PR DESCRIPTION
Create a `purge(list)` method, used by the current and more convenient purge_path and purge_url to make purge requests, but DRYs up the requests, and adds a method that can be used to purge multiple urls in a single API request easily.

This is a breaking change in that the `purge_path` method is updated to make a single API request.

fixes #4 and #5 
